### PR TITLE
:warning: Changes extraTargets to extraServices

### DIFF
--- a/charts/capi-cr/Chart.yaml
+++ b/charts/capi-cr/Chart.yaml
@@ -3,5 +3,9 @@ name: capi-cr
 description: Helm Chart for deploying a Kubernetes Cluster with the cluster-api.
 home: https://github.com/syself/charts/tree/main/charts/capi-cr
 type: application
-version: 1.0.4
 icon: https://cluster-api.sigs.k8s.io/#kubernetes-cluster-apidiv-stylefloat-right-position-relative-display-inlineimg-srcimagesintroductionpng-width160px-div
+maintainers:
+  - name: Syself
+    email: info@syself.com
+    url: https://github.com/syself
+version: 1.0.5

--- a/charts/capi-cr/ci/full-specified.yaml
+++ b/charts/capi-cr/ci/full-specified.yaml
@@ -325,7 +325,7 @@ hetzner:
       type: lb11
       algorithm: least_connection
       port: 6443
-      extraTargets:
+      extraServices:
       - listenPort: 443
         destinationPort: 6443
         protocol: tcp

--- a/charts/capi-cr/templates/infrastructure.cluster.x-k8s.io/hetzner_cluster.yaml
+++ b/charts/capi-cr/templates/infrastructure.cluster.x-k8s.io/hetzner_cluster.yaml
@@ -50,9 +50,9 @@ spec:
     type: {{ $hetznerCluster.controlPlaneLoadBalancer.type | default "lb11" }}
     algorithm: {{ $hetznerCluster.controlPlaneLoadBalancer.algorithm | default "round_robin" }}
     port: {{ $hetznerCluster.controlPlaneLoadBalancer.port | default "6443" }}
-    {{- if hasKey $hetznerCluster.controlPlaneLoadBalancer "extraTargets" }}
-    {{- with $hetznerCluster.controlPlaneLoadBalancer.extraTargets }}
-    extraTargets:
+    {{- if hasKey $hetznerCluster.controlPlaneLoadBalancer "extraServices" }}
+    {{- with $hetznerCluster.controlPlaneLoadBalancer.extraServices }}
+    extraServices:
     {{- toYaml . | nindent 4 }}
     {{- end }}
     {{- end }}

--- a/charts/capi-cr/values.yaml
+++ b/charts/capi-cr/values.yaml
@@ -235,7 +235,7 @@ hetzner: {}
   #     # -- Specifies the destination Port of the loadbalancer this must be equal with cluster.apiServerPort
   #     port: 6443
   #     # -- Here extra Targets for the Hetzner Loadbalancer could be specified. 
-  #     extraTargets: []
+  #     extraServices: []
   #     # - listenPort: 443
   #     #   destinationPort: 6443
   #     #   protocol: tcp


### PR DESCRIPTION
**What type of PR is this?**

/kind api-change        Adds, removes, or changes an API

**What this PR does / why we need it**:
Changes extraTargets to extraServices. As since v1.0.0-alpha.10 of the cluster-api-provider-hetzner this has a new name.



