### PR TITLE
:seedling: updates ccm defaults

### DIFF
--- a/charts/ccm-hcloud/Chart.yaml
+++ b/charts/ccm-hcloud/Chart.yaml
@@ -8,4 +8,4 @@ maintainers:
     email: info@syself.com
     url: https://github.com/syself
 appVersion: "1.12.1"
-version: 1.0.9
+version: 1.0.10

--- a/charts/ccm-hcloud/values.yaml
+++ b/charts/ccm-hcloud/values.yaml
@@ -2,7 +2,7 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-replicaCount: 2
+replicaCount: 1
 
 image:
   repository: docker.io/hetznercloud/hcloud-cloud-controller-manager


### PR DESCRIPTION
**What type of PR is this?**
/kind bug               

**What this PR does / why we need it**:
If only one node is available it is not possible to run two ccm on the same node. Therefore the default replica should be 1.

