### PR TITLE
:sparkles: adding ccm-hetzner

### DIFF
--- a/charts/ccm-hetzner/.helmignore
+++ b/charts/ccm-hetzner/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/ccm-hetzner/Chart.yaml
+++ b/charts/ccm-hetzner/Chart.yaml
@@ -1,0 +1,11 @@
+apiVersion: v2
+name: ccm-hetzner
+description: Helm Chart for Hcloud Cloud Controller Manager
+type: application
+home: https://github.com/syself/charts/tree/main/charts/ccm-hetzner
+maintainers:
+  - name: Syself
+    email: info@syself.com
+    url: https://github.com/syself
+appVersion: "1.12.1"
+version: 1.1.0

--- a/charts/ccm-hetzner/templates/_helpers.tpl
+++ b/charts/ccm-hetzner/templates/_helpers.tpl
@@ -1,0 +1,63 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "ccm-hetzner.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "ccm-hetzner.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "ccm-hetzner.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "ccm-hetzner.labels" -}}
+helm.sh/chart: {{ include "ccm-hetzner.chart" . }}
+app: ccm
+{{ include "ccm-hetzner.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "ccm-hetzner.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "ccm-hetzner.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "ccm-hetzner.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "ccm-hetzner.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/ccm-hetzner/templates/deployment.yaml
+++ b/charts/ccm-hetzner/templates/deployment.yaml
@@ -1,0 +1,125 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "ccm-hetzner.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "ccm-hetzner.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  revisionHistoryLimit: 5
+  selector:
+    matchLabels:
+      {{- include "ccm-hetzner.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "ccm-hetzner.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      dnsPolicy: Default
+      serviceAccountName: {{ include "ccm-hetzner.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      tolerations:
+        # this taint is set by all kubelets running `--cloud-provider=external`
+        # so we should tolerate it to schedule the cloud controller manager
+        - key: "node.cloudprovider.kubernetes.io/uninitialized"
+          value: "true"
+          effect: "NoSchedule"
+        - key: "CriticalAddonsOnly"
+          operator: "Exists"
+        # cloud controller manages should be able to run on masters
+        - key: "node-role.kubernetes.io/master"
+          effect: NoSchedule
+          operator: Exists
+        - key: "node-role.kubernetes.io/control-plane"
+          effect: NoSchedule
+          operator: Exists
+        - key: "node.kubernetes.io/not-ready"
+          effect: "NoSchedule"
+      {{- with .Values.tolerations }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- if .Values.privateNetwork.enabled }}
+      hostNetwork: true
+{{- end }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command:
+            - "/bin/hetzner-cloud-controller-manager"
+            - "--cloud-provider=hetzner"
+            - "--leader-elect={{ .Values.env.leaderElect }}"
+            - "--allow-untagged-cloud"
+{{- if .Values.privateNetwork.enabled }}
+            - "--allocate-node-cidrs=true"
+            - "--cluster-cidr={{ .Values.privateNetwork.clusterSubnet }}"
+{{- end }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          env:
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: HCLOUD_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  {{- if .Values.secret.create }}
+                  name: {{ include "ccm-hetzner.fullname" . }}
+                  {{- else }}
+                  name: {{ .Values.secret.name }}
+                  {{- end }}
+                  key: {{ .Values.secret.key.token }}
+            - name: ROBOT_USER_NAME
+              valueFrom:
+                secretKeyRef:
+                  {{- if .Values.secret.create }}
+                  name: {{ include "ccm-hetzner.fullname" . }}
+                  {{- else }}
+                  name: {{ .Values.secret.name }}
+                  {{- end }}
+                  key: {{ .Values.secret.key.robotUserName }}
+            - name: ROBOT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  {{- if .Values.secret.create }}
+                  name: {{ include "ccm-hetzner.fullname" . }}
+                  {{- else }}
+                  name: {{ .Values.secret.name }}
+                  {{- end }}
+                  key: {{ .Values.secret.key.robotPassword }}
+            - name: HCLOUD_DEBUG
+              value: "{{ .Values.env.debug }}"
+            - name: HCLOUD_LOAD_BALANCERS_ENABLED
+              value: "{{ .Values.env.loadBalancers }}"
+            {{- if .Values.privateNetwork.enabled }}
+            - name: HCLOUD_NETWORK
+              valueFrom:
+                secretKeyRef:
+                  {{- if .Values.secret.create }}
+                  name: {{ include "ccm-hetzner.fullname" . }}
+                  {{- else }}
+                  name: {{ .Values.secret.name }}
+                  {{- end }}
+                  key: {{ .Values.secret.key.network }}
+            {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/ccm-hetzner/templates/pdb.yaml
+++ b/charts/ccm-hetzner/templates/pdb.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.pdb.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "ccm-hetzner.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  minAvailable: {{ .Values.pdb.minAvailable }}
+  maxUnavailable: {{ .Values.pdb.maxUnavailable }}
+  selector:
+    matchLabels:
+      {{- include "ccm-hetzner.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/charts/ccm-hetzner/templates/secret.yaml
+++ b/charts/ccm-hetzner/templates/secret.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.secret.create -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "ccm-hetzner.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "ccm-hetzner.labels" . | nindent 4 }}
+stringData:
+  {{ .Values.secret.key.token }}: {{ .Values.env.hcloudApiToken | b64enc }}
+  {{ .Values.secret.key.robotUserName }}: {{ .Values.env.robotUser | b64enc }}
+  {{ .Values.secret.key.robotPassword }}: {{ .Values.env.robotPassword | b64enc }}
+{{- if .Values.privateNetwork.enabled }}
+  {{ .Values.secret.networkKeyName }}: {{ .Values.privateNetwork.network.id | b64enc }}
+{{- end -}}  
+{{- end -}}

--- a/charts/ccm-hetzner/templates/serviceaccount.yaml
+++ b/charts/ccm-hetzner/templates/serviceaccount.yaml
@@ -1,0 +1,29 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "ccm-hetzner.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "ccm-hetzner.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ include "ccm-hetzner.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "ccm-hetzner.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "ccm-hetzner.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/charts/ccm-hetzner/values.yaml
+++ b/charts/ccm-hetzner/values.yaml
@@ -1,0 +1,76 @@
+# Default values for ccm-hetzner.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+
+image:
+  repository: quay.io/syself/hetzner-cloud-controller-manager
+  pullPolicy: Always
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: "v1.12.1"
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+env:
+  debug: false
+  loadBalancers: true
+  leaderElect: true
+  hcloudApiToken:    # HCloud API Token, fill this only if you don't have a secret already with the token. And set secret.create=true
+  robotUser:    # Robot User, fill this only if you don't have a secret already with the token. And set secret.create=true
+  robotPassword:    # Robot Password, fill this only if you don't have a secret already with the token. And set secret.create=true
+
+
+privateNetwork:
+  enabled: false
+  network:
+    id:   # If you have a secret with the key network leave it empty. If you specify it manually provide the name or ID of the Hcloud Network here. And set secret.create=true
+  clusterSubnet: 10.244.0.0/16   # Pod CIDR
+
+secret:
+  create: false
+  name: hetzner # Name of an existing secret 
+  key:
+    token: hcloud # Name of an existing key for the hcloud-token in the above specified secret
+    robotUserName: robot-user
+    robotPassword: robot-password
+    network: network # Name of an existing key for the hcloud-network in the above specified secret
+
+pdb:
+  enabled: true
+  minAvailable: 1
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+podAnnotations: {}
+
+podSecurityContext: {}
+  # fsGroup: 2000
+
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+resources:
+  requests:
+    cpu: 100m
+    memory: 50Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}


### PR DESCRIPTION

**What type of PR is this?**

/kind feature           New functionality.

**What this PR does / why we need it**:
Adding cloud-controller-manager for hetzner. Supports hcloud and dedicated servers / robot
