### PR TITLE
🐛 Fix missing default root-server nodeAffinity and NoSchedule toleration

### DIFF
--- a/charts/csi-hcloud/templates/controller-deployment.yaml
+++ b/charts/csi-hcloud/templates/controller-deployment.yaml
@@ -103,9 +103,10 @@ spec:
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.affinity }}
       affinity:
+        {{- with .Values.affinity }}
         {{- toYaml . | nindent 8 }}
+        {{- end }}
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
@@ -114,7 +115,6 @@ spec:
                 operator: NotIn
                 values:
                 - "true"
-      {{- end }}
       {{- with .Values.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}

--- a/charts/csi-hcloud/templates/controller-deployment.yaml
+++ b/charts/csi-hcloud/templates/controller-deployment.yaml
@@ -106,6 +106,14 @@ spec:
       {{- with .Values.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: instance.hetzner.cloud/is-root-server
+                operator: NotIn
+                values:
+                - "true"
       {{- end }}
       {{- with .Values.tolerations }}
       tolerations:

--- a/charts/csi-hcloud/templates/node-daemonset.yaml
+++ b/charts/csi-hcloud/templates/node-daemonset.yaml
@@ -34,6 +34,8 @@ spec:
       tolerations:
       - effect: NoExecute
         operator: Exists
+      - effect: NoSchedule
+        operator: Exists
       - key: CriticalAddonsOnly
         operator: Exists
       affinity:


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

Default DaemonSet toleration `NoSchedule` was missing and so was the nodeAffinity `instance.hetzner.cloud/is-root-server` for the controller-deployment.

**Which issue(s) this PR fixes**

Fixes #50