### PR TITLE
🐛 Fix missing tag override

### DIFF
--- a/charts/ccm-hetzner/values.yaml
+++ b/charts/ccm-hetzner/values.yaml
@@ -8,7 +8,7 @@ image:
   repository: quay.io/syself/hetzner-cloud-controller-manager
   pullPolicy: Always
   # Overrides the image tag whose default is the chart appVersion.
-  tag: ""
+  tag: "v1.13.2-0.0.1"
 
 imagePullSecrets: []
 nameOverride: ""


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

`tag` in ccm-hetzner v1.1.5 `values.yaml` is empty so image-pulling fails for version `1.13.2-0.0.1` as quay.io only holds `v`-prefixed-images, i.e. `v1.13.2-0.0.1`. 

**Which issue(s) this PR fixes**

Fixes #52