### PR TITLE
:seedling: konnectivity agent less replicas for small clusters.

### DIFF
--- a/charts/konnectivity-agent/Chart.yaml
+++ b/charts/konnectivity-agent/Chart.yaml
@@ -13,5 +13,5 @@ dependencies:
     version: 1.0.0
     alias: proportional-autoscaler
     condition: proportional-autoscaler.enabled
-appVersion: v0.1.2
-version: 1.0.5
+appVersion: v0.1.3
+version: 1.0.6

--- a/charts/konnectivity-agent/values.yaml
+++ b/charts/konnectivity-agent/values.yaml
@@ -143,7 +143,7 @@ proportional-autoscaler:
     linear:
       coresPerReplica: 32
       nodesPerReplica: 4
-      min: 3
+      min: 2
       max: 50
       preventSinglePointFailure: true
       includeUnschedulableNodes: true


### PR DESCRIPTION
**What type of PR is this?**

konnectivity agent less replicas for small clusters.

/kind feature           New functionality.

If there are not enough worker-nodes, then you get errors like this:

```
❯ k get -o yaml -n kube-system deployments.apps  konnectivity-agent
....
status:
  availableReplicas: 2
  conditions:
  - lastTransitionTime: "2023-08-15T07:45:46Z"
    lastUpdateTime: "2023-08-15T07:52:33Z"
    message: ReplicaSet "konnectivity-agent-6c5947646d" has successfully progressed.
    reason: NewReplicaSetAvailable
    status: "True"
    type: Progressing
  - lastTransitionTime: "2023-08-15T12:33:35Z"
    lastUpdateTime: "2023-08-15T12:33:35Z"
    message: Deployment does not have minimum availability.
    reason: MinimumReplicasUnavailable
    status: "False"
    type: Available
  observedGeneration: 154
  readyReplicas: 2
  replicas: 3
  unavailableReplicas: 1
  updatedReplicas: 3
```

This PR reduces the number if mininmal available pods to 2.

This means the above error still appears in clusters with one worker node.
