### PR TITLE
🌱 fix pdb issue in konnectivity-agent helm chart

### DIFF
--- a/charts/konnectivity-agent/Chart.yaml
+++ b/charts/konnectivity-agent/Chart.yaml
@@ -14,4 +14,4 @@ dependencies:
     alias: proportional-autoscaler
     condition: proportional-autoscaler.enabled
 appVersion: v1.8.9
-version: 1.0.11
+version: 1.0.12

--- a/charts/konnectivity-agent/templates/pdb.yaml
+++ b/charts/konnectivity-agent/templates/pdb.yaml
@@ -5,8 +5,12 @@ metadata:
   name: {{ include "konnectivity-agent.fullname" . }}
   namespace: {{ .Release.Namespace }}
 spec:
+  {{- if .Values.pdb.minAvailable }}
   minAvailable: {{ .Values.pdb.minAvailable }}
-  maxUnavailable: {{ .Values.pdb.maxUnavailable }}
+  {{- end  }}
+  {{- if or .Values.pdb.maxUnavailable ( not .Values.pdb.minAvailable ) }}
+  maxUnavailable: {{ .Values.pdb.maxUnavailable | default 1 }}
+  {{- end  }}
   selector:
     matchLabels:
       {{- include "konnectivity-agent.selectorLabels" . | nindent 6 }}

--- a/charts/konnectivity-agent/values.yaml
+++ b/charts/konnectivity-agent/values.yaml
@@ -20,7 +20,8 @@ ports:
 
 pdb:
   enabled: true
-  maxUnavailable: 2
+  # please note that you should only define one of minAvailable or maxUnavailable.
+  minAvailable: 1
 
 serviceAccount:
   # The name of the service account to use.


### PR DESCRIPTION
      fix pdb issue in konnectivity-agent helm chart
      
      we can only set maxUnavailable or minAvailable in the spec of pdb, not
      both.
      
      In the current helm chart, we have both set always and if one of the
      keys is missing in the values.yaml then the block is empty in the
      rendered manifest.
      
      This is conflicting with with the spec of pdb.
      this commit refactors the helm chart so that if we have only one key
      then the generated manifest then should contain only that key not the
      other one.
      
      For example: If we have `minAvailable` defined then the generated
      manifest shouldn't contain `maxUnavailable`
      
      If the user defines both key in the values.yaml then that's wrong and
      I've added a note for the same that only one out of minAvailable and
      maxUnavailable should be defined.
      
      Signed-off-by: kranurag7 <anurag.kumar@syself.com>