### PR TITLE
:seedling: Update hcloud-csi to 2.16

### DIFF
--- a/charts/hcloud-csi/templates/controller/deployment.yaml
+++ b/charts/hcloud-csi/templates/controller/deployment.yaml
@@ -110,7 +110,8 @@ spec:
         - name: hcloud-csi-driver
           image: {{ include "common.images.image" (dict "imageRoot" .Values.controller.image.hcloudCSIDriver "global" .Values.global) }}
           imagePullPolicy: {{ .Values.controller.image.hcloudCSIDriver.pullPolicy }}
-          command: [/bin/hcloud-csi-driver-controller]
+          args:
+            - -controller
           volumeMounts:
             - name: socket-dir
               mountPath: /run/csi

--- a/charts/hcloud-csi/templates/node/daemonset.yaml
+++ b/charts/hcloud-csi/templates/node/daemonset.yaml
@@ -92,7 +92,8 @@ spec:
         - name: hcloud-csi-driver
           image: {{ include "common.images.image" (dict "imageRoot" .Values.node.image.hcloudCSIDriver "global" .Values.global) }}
           imagePullPolicy: {{ .Values.node.image.pullPolicy }}
-          command: [/bin/hcloud-csi-driver-node]
+          args:
+          - -node
           volumeMounts:
             - name: kubelet-dir
               mountPath: {{ .Values.node.kubeletDir }}


### PR DESCRIPTION
closes https://github.com/syself/cluster-stacks/issues/686

The csi-driver change to an AIO (all-in-one binary): https://github.com/hetznercloud/csi-driver/releases/tag/v2.16.0