### PR TITLE
:seedling: konnectivity-server fix label selector.

### DIFF
--- a/charts/konnectivity-agent/templates/_helpers.tpl
+++ b/charts/konnectivity-agent/templates/_helpers.tpl
@@ -63,7 +63,7 @@ Selector labels for server
 {{- define "konnectivity-server.selectorLabels" -}}
 app.kubernetes.io/name: konnectivity-server
 app.kubernetes.io/instance: konnectivity-server
-k8s-app: konnectivity-agent
+k8s-app: konnectivity-server
 {{- end }}
 
 {{/*


### PR DESCRIPTION
konnectivity-server fix label selector.

But: Why do we create a Kubernetes Service, when nobody uses it?

These docs do not show a Kubernetes Service: https://kubernetes.io/docs/tasks/extend-kubernetes/setup-konnectivity/