### PR TITLE
:seedling: Syself Hetzner CCM v2.0.5 (fix for bare-metal control-planes)

### DIFF
--- a/charts/ccm-hetzner/Chart.yaml
+++ b/charts/ccm-hetzner/Chart.yaml
@@ -7,5 +7,5 @@ maintainers:
   - name: Syself
     email: info@syself.com
     url: https://github.com/syself
-appVersion: "v2.0.4"
-version: 2.0.4
+appVersion: "v2.0.5"
+version: 2.0.5


### PR DESCRIPTION
Syself Hetzner CCM v2.0.5 (fix for bare-metal control-planes)