### PR TITLE
🐛 Fix duplicate volumeMounts in hcloud-csi controller

### DIFF
--- a/charts/hcloud-csi/Chart.yaml
+++ b/charts/hcloud-csi/Chart.yaml
@@ -7,5 +7,5 @@ maintainers:
   - name: Syself
     email: info@syself.com
     url: https://github.com/syself
-version: 1.3.0
+version: 1.3.1
 appVersion: v2.16.0

--- a/charts/hcloud-csi/templates/controller/deployment.yaml
+++ b/charts/hcloud-csi/templates/controller/deployment.yaml
@@ -112,9 +112,6 @@ spec:
           imagePullPolicy: {{ .Values.controller.image.hcloudCSIDriver.pullPolicy }}
           args:
           - -controller
-          volumeMounts:
-            - name: socket-dir
-              mountPath: /run/csi
           env:
             - name: CSI_ENDPOINT
               value: unix:///run/csi/socket


### PR DESCRIPTION
## Summary
- remove the duplicated `volumeMounts` key from the `hcloud-csi-driver` container in `charts/hcloud-csi/templates/controller/deployment.yaml`
- bump the chart version to `1.3.1`

## Why
The template currently renders `volumeMounts` twice in the same YAML mapping for the `hcloud-csi-driver` container. Helm will still render the manifest, but strict YAML consumers reject it as invalid due to the duplicate key.

This showed up downstream when rendering the chart and passing the result to a YAML parser:

```text
mapping key "volumeMounts" already defined
```

The later `volumeMounts` block is already the complete one because it also appends `controller.extraVolumeMounts`, so removing the earlier block is the minimal fix.

## Validation
- `helm template test charts/hcloud-csi > /tmp/hcloud-csi-template.yaml`
- parsed `/tmp/hcloud-csi-template.yaml` successfully with PyYAML
