### PR TITLE
:seedling: ccm v2.0.6 (support upstream providerID)

### DIFF
--- a/charts/ccm-hetzner/Chart.yaml
+++ b/charts/ccm-hetzner/Chart.yaml
@@ -7,5 +7,5 @@ maintainers:
   - name: Syself
     email: info@syself.com
     url: https://github.com/syself
-appVersion: "v2.0.5"
-version: 2.0.5
+appVersion: "v2.0.6"
+version: 2.0.6


### PR DESCRIPTION
ccm v2.0.6 (support upstream providerID)